### PR TITLE
PST-2544: Fix column type regex

### DIFF
--- a/src/Extractor/SnowflakeUtils.php
+++ b/src/Extractor/SnowflakeUtils.php
@@ -9,7 +9,7 @@ class SnowflakeUtils
     public static function parseTypeAndLength(string $rawType): array
     {
         // Eg. NUMBER(38,0) / DATE / VARCHAR(16777216)
-        preg_match('~^([^()]+)(?:\((.+)\))?$~', $rawType, $m);
+        preg_match('~^([^()]+)(?:\((.+)\))?~', $rawType, $m);
         $type = $m[1] ?? null;
         $length = $m[2] ?? null;
         return [$type, $length];

--- a/tests/phpunit/SnowflakeUtilsTest.php
+++ b/tests/phpunit/SnowflakeUtilsTest.php
@@ -21,6 +21,16 @@ class SnowflakeUtilsTest extends TestCase
     public function getTestData(): iterable
     {
         yield [
+            '',
+            [null, null],
+        ];
+
+        yield [
+            '(FOO)',
+            [null, null],
+        ];
+
+        yield [
             'DATE',
             ['DATE', null],
         ];
@@ -32,6 +42,11 @@ class SnowflakeUtilsTest extends TestCase
 
         yield [
             'VARCHAR(16777216)',
+            ['VARCHAR', '16777216'],
+        ];
+
+        yield [
+            'VARCHAR(16777216) COLLATE \'en-ps\'',
             ['VARCHAR', '16777216'],
         ];
     }


### PR DESCRIPTION
Remove `$` from [regex](https://github.com/keboola/db-extractor-snowflake/blob/2f01660917e91adb3b19994b78c3bec78c0fac9a/src/Extractor/SnowflakeUtils.php#L12) to allow successful parsing of `VARCHAR(n) COLLATE '...'` column type