### PR TITLE
feat: log number of unloaded rows

### DIFF
--- a/src/Extractor/SnowsqlExportAdapter.php
+++ b/src/Extractor/SnowsqlExportAdapter.php
@@ -71,6 +71,8 @@ class SnowsqlExportAdapter implements ExportAdapter
         $res = $this->connection->query($copyCommand)->fetchAll();
         $rowCount = (int) ($res[0]['rows_unloaded'] ?? 0);
 
+        $this->logger->info(sprintf('%d rows copied to internal staging.', $rowCount));
+
         // Download CSV using snowsql
         $process = $this->runDownloadCommand($exportConfig, $csvFilePath);
 

--- a/tests/functional/incremental-fetching-empty-rows/expected-stdout
+++ b/tests/functional/incremental-fetching-empty-rows/expected-stdout
@@ -1,4 +1,5 @@
 Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowflakecomputing.com;Port=443;Tracing=0;Database="%s";Schema="%s";application="Keboola_Connection"".
 Exporting "auto-increment-timestamp" to "in.c-main.auto-increment-timestamp".
+0 rows copied to internal staging.
 Downloading data from Snowflake.
 0 files (0 B) downloaded.

--- a/tests/functional/run-action-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-native-types-manifest/expected-stdout
@@ -1,9 +1,11 @@
 Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowflakecomputing.com;Port=443;Tracing=0;Database="%s";Schema="%s";application="Keboola_Connection"".
 Exporting "sales" to "in.c-main.escaping".
+7 rows copied to internal staging.
 Downloading data from Snowflake.
 1 files (216 B) downloaded.
 Exported "7" rows to "in.c-main.escaping".
 Exporting "sales" to "in.c-main.sales".
+100 rows copied to internal staging.
 Downloading data from Snowflake.
 1 files (3.%i KB) downloaded.
 Exported "100" rows to "in.c-main.sales".

--- a/tests/functional/run-action-null-column/expected-stdout
+++ b/tests/functional/run-action-null-column/expected-stdout
@@ -1,5 +1,6 @@
 Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowflakecomputing.com;Port=443;Tracing=0;Database="%s";Schema="%s";application="Keboola_Connection"".
 Exporting "null column" to "in.c-main.null-column-table".
+1 rows copied to internal staging.
 Downloading data from Snowflake.
 1 files (21 B) downloaded.
 Exported "1" rows to "in.c-main.null-column-table".

--- a/tests/functional/run-action-row-debug-logging/expected-stdout
+++ b/tests/functional/run-action-row-debug-logging/expected-stdout
@@ -3,6 +3,7 @@ Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowfl
 Exporting "sales" to "in.c-main.escaping".
 [%s] DEBUG: Running query "REMOVE @~/in.c-main.escaping;". [] []
 [%s] DEBUG: Running query "             COPY INTO @~/in.c-main.escaping/part             FROM (SELECT * FROM "escaping")             FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER = ',' FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = '\\' COMPRESSION = 'GZIP' NULL_IF=())             HEADER = false             MAX_FILE_SIZE=50000000             OVERWRITE = TRUE             ;             ". [] []
+7 rows copied to internal staging.
 [%s] DEBUG: USE DATABASE "COMPONENT_TESTING"; USE SCHEMA "COMPONENT_TESTING"."COMPONENT_TEST"; GET @~/in.c-main.escaping file:///opt/snowsqltempdir/run-%s.%s/out/tables/in.c-main.escaping.csv.gz; [] []
 Downloading data from Snowflake.
 [%s] DEBUG: snowsql --noup --config /opt/snowsqltempdir/ex-snowflake-adapter/run-%s.%s/snowsql.config -c downloader -f /opt/snowsqltempdir/ex-snowflake-adapter/run-%s.%s/%s-snowsql.sql [] []

--- a/tests/functional/run-action-row/expected-stdout
+++ b/tests/functional/run-action-row/expected-stdout
@@ -1,5 +1,6 @@
 Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowflakecomputing.com;Port=443;Tracing=0;Database="%s";Schema="%s";application="Keboola_Connection"".
 Exporting "sales" to "in.c-main.escaping".
+7 rows copied to internal staging.
 Downloading data from Snowflake.
 1 files (216 B) downloaded.
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/functional/run-action/expected-stdout
+++ b/tests/functional/run-action/expected-stdout
@@ -1,9 +1,11 @@
 Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowflakecomputing.com;Port=443;Tracing=0;Database="%s";Schema="%s";application="Keboola_Connection"".
 Exporting "sales" to "in.c-main.escaping".
+7 rows copied to internal staging.
 Downloading data from Snowflake.
 1 files (216 B) downloaded.
 Exported "7" rows to "in.c-main.escaping".
 Exporting "sales" to "in.c-main.sales".
+100 rows copied to internal staging.
 Downloading data from Snowflake.
 1 files (3.%i KB) downloaded.
 Exported "100" rows to "in.c-main.sales".

--- a/tests/functional/semi-structured/expected-stdout
+++ b/tests/functional/semi-structured/expected-stdout
@@ -1,5 +1,6 @@
 Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowflakecomputing.com;Port=443;Tracing=0;Database="%s";Schema="%s";application="Keboola_Connection"".
 Exporting "semi-structured" to "in.c-main.semi-structured".
+1 rows copied to internal staging.
 Downloading data from Snowflake.
 1 files (62 B) downloaded.
 Exported "1" rows to "in.c-main.semi-structured".


### PR DESCRIPTION
Mam podezreni, ze se tohle deje na "cizich" Snowflakach, kdyz extraktor nestahne zadne rows.
Timhle logovanim by se to melo overit.

https://keboola.atlassian.net/browse/SUPPORT-4342

[Data dog errors](https://app.datadoghq.eu/logs?query=snowsql&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZX6V9RFs2n3lAAAABhBWlg2VjkxaUFBQkdzWXA0VU5CVHFnQVUAAAAkMDE5NWZhNmMtZjM0OS00MGU0LTk1MWItNzllMmRmNjUyYWZhAApn4A&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1741518007023&to_ts=1744110007023&live=true)