### PR TITLE
fix: add trailing slash to REMOVE command to prevent prefix matching in parallel extractions

### DIFF
--- a/src/Extractor/SnowsqlExportAdapter.php
+++ b/src/Extractor/SnowsqlExportAdapter.php
@@ -258,7 +258,7 @@ class SnowsqlExportAdapter implements ExportAdapter
         }
 
         $sql[] = sprintf(
-            'GET @~/%s file://%s;',
+            'GET @~/%s/ file://%s;',
             $exportConfig->getOutputTable(),
             $outputDataDir,
         );

--- a/src/Extractor/SnowsqlExportAdapter.php
+++ b/src/Extractor/SnowsqlExportAdapter.php
@@ -136,7 +136,7 @@ class SnowsqlExportAdapter implements ExportAdapter
 
     private function cleanupTableStage(string $tmpTableName): void
     {
-        $sql = sprintf('REMOVE @~/%s;', $tmpTableName);
+        $sql = sprintf('REMOVE @~/%s/;', $tmpTableName);
         $this->connection->query($sql);
     }
 

--- a/tests/functional/run-action-row-debug-logging/expected-stdout
+++ b/tests/functional/run-action-row-debug-logging/expected-stdout
@@ -4,7 +4,7 @@ Exporting "sales" to "in.c-main.escaping".
 [%s] DEBUG: Running query "REMOVE @~/in.c-main.escaping/;". [] []
 [%s] DEBUG: Running query "             COPY INTO @~/in.c-main.escaping/part             FROM (SELECT * FROM "escaping")             FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER = ',' FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = '\\' COMPRESSION = 'GZIP' NULL_IF=())             HEADER = false             MAX_FILE_SIZE=50000000             OVERWRITE = TRUE             ;             ". [] []
 7 rows copied to internal staging.
-[%s] DEBUG: USE DATABASE "COMPONENT_TESTING"; USE SCHEMA "COMPONENT_TESTING"."COMPONENT_TEST"; GET @~/in.c-main.escaping file:///opt/snowsqltempdir/run-%s.%s/out/tables/in.c-main.escaping.csv.gz; [] []
+[%s] DEBUG: USE DATABASE "COMPONENT_TESTING"; USE SCHEMA "COMPONENT_TESTING"."COMPONENT_TEST"; GET @~/in.c-main.escaping/ file:///opt/snowsqltempdir/run-%s.%s/out/tables/in.c-main.escaping.csv.gz; [] []
 Downloading data from Snowflake.
 [%s] DEBUG: snowsql --noup --config /opt/snowsqltempdir/ex-snowflake-adapter/run-%s.%s/snowsql.config -c downloader -f /opt/snowsqltempdir/ex-snowflake-adapter/run-%s.%s/%s-snowsql.sql [] []
 1 files (216 B) downloaded.

--- a/tests/functional/run-action-row-debug-logging/expected-stdout
+++ b/tests/functional/run-action-row-debug-logging/expected-stdout
@@ -1,7 +1,7 @@
 [%s] DEBUG: Component initialization completed [] []
 Creating ODBC connection to "Driver=SnowflakeDSIIDriver;Server=kebooladev.snowflakecomputing.com;Port=443;Tracing=0;Database="COMPONENT_TESTING";Schema="COMPONENT_TEST";application="Keboola_Connection"".
 Exporting "sales" to "in.c-main.escaping".
-[%s] DEBUG: Running query "REMOVE @~/in.c-main.escaping;". [] []
+[%s] DEBUG: Running query "REMOVE @~/in.c-main.escaping/;". [] []
 [%s] DEBUG: Running query "             COPY INTO @~/in.c-main.escaping/part             FROM (SELECT * FROM "escaping")             FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER = ',' FIELD_OPTIONALLY_ENCLOSED_BY = '"' ESCAPE_UNENCLOSED_FIELD = '\\' COMPRESSION = 'GZIP' NULL_IF=())             HEADER = false             MAX_FILE_SIZE=50000000             OVERWRITE = TRUE             ;             ". [] []
 7 rows copied to internal staging.
 [%s] DEBUG: USE DATABASE "COMPONENT_TESTING"; USE SCHEMA "COMPONENT_TESTING"."COMPONENT_TEST"; GET @~/in.c-main.escaping file:///opt/snowsqltempdir/run-%s.%s/out/tables/in.c-main.escaping.csv.gz; [] []
@@ -10,5 +10,5 @@ Downloading data from Snowflake.
 1 files (216 B) downloaded.
 [%s] DEBUG: Running query "SELECT * FROM (SELECT * FROM "escaping") LIMIT 0;". [] []
 [%s] DEBUG: Running query "DESC RESULT LAST_QUERY_ID()". [] []
-[%s] DEBUG: Running query "REMOVE @~/in.c-main.escaping;". [] []
+[%s] DEBUG: Running query "REMOVE @~/in.c-main.escaping/;". [] []
 Exported "7" rows to "in.c-main.escaping".

--- a/tests/phpunit/SnowsqlExportAdapterTest.php
+++ b/tests/phpunit/SnowsqlExportAdapterTest.php
@@ -158,43 +158,12 @@ class SnowsqlExportAdapterTest extends TestCase
         $schema = (string) getenv('SNOWFLAKE_DB_SCHEMA');
         $manager = new DatabaseManager($connection);
 
-        // Create and populate first table: "simple"
-        $manager->createTable(
-            'simple',
-            ['id' => 'NUMBER', 'name' => 'VARCHAR'],
-            $schema,
-        );
-        $manager->insertRows(
-            'simple',
-            ['id', 'name'],
-            [
-                [1, 'foo'],
-                [2, 'bar'],
-                [3, 'baz'],
-            ],
-        );
-
-        // Create and populate second table: "simple-date" (prefix matches "simple")
-        $manager->createTable(
-            'simple-date',
-            ['id' => 'NUMBER', 'name' => 'VARCHAR', 'created_at' => 'DATE'],
-            $schema,
-        );
-        $manager->insertRows(
-            'simple-date',
-            ['id', 'name', 'created_at'],
-            [
-                [1, 'alpha', '2024-01-01'],
-                [2, 'beta', '2024-01-02'],
-            ],
-        );
-
         // Manually stage BOTH tables simultaneously (simulates parallel runs)
         // This is the key difference from normal functional tests
         $stageName1 = 'in.c-main.simple';
         $stageName2 = 'in.c-main.simple-date';
 
-        // Clean up any existing stage files first
+        // Clean up any existing stage files from previous test runs
         try {
             $connection->query("REMOVE @~/$stageName1/;");
         } catch (Throwable $e) {
@@ -206,109 +175,156 @@ class SnowsqlExportAdapterTest extends TestCase
             // Ignore errors if stage doesn't exist
         }
 
-        // Upload table 1 to stage
-        $connection->query("
-            COPY INTO @~/$stageName1/part
-            FROM (SELECT * FROM \"simple\")
-            FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER=',' COMPRESSION='GZIP')
-            OVERWRITE = TRUE;
-        ");
+        try {
+            // Create and populate first table: "simple"
+            $manager->createTable(
+                'simple',
+                ['id' => 'NUMBER', 'name' => 'VARCHAR'],
+                $schema,
+            );
+            $manager->insertRows(
+                'simple',
+                ['id', 'name'],
+                [
+                    [1, 'foo'],
+                    [2, 'bar'],
+                    [3, 'baz'],
+                ],
+            );
 
-        // Upload table 2 to stage
-        $connection->query("
-            COPY INTO @~/$stageName2/part
-            FROM (SELECT * FROM \"simple-date\")
-            FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER=',' COMPRESSION='GZIP')
-            OVERWRITE = TRUE;
-        ");
+            // Create and populate second table: "simple-date" (prefix matches "simple")
+            $manager->createTable(
+                'simple-date',
+                ['id' => 'NUMBER', 'name' => 'VARCHAR', 'created_at' => 'DATE'],
+                $schema,
+            );
+            $manager->insertRows(
+                'simple-date',
+                ['id', 'name', 'created_at'],
+                [
+                    [1, 'alpha', '2024-01-01'],
+                    [2, 'beta', '2024-01-02'],
+                ],
+            );
 
-        // Verify both are in stage
-        $listResult = $connection->fetchAll("LIST @~/$stageName1/;");
-        $this->assertNotEmpty($listResult, 'simple table files should be staged');
+            // Upload table 1 to stage
+            $connection->query("
+                COPY INTO @~/$stageName1/part
+                FROM (SELECT * FROM \"simple\")
+                FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER=',' COMPRESSION='GZIP')
+                OVERWRITE = TRUE;
+            ");
 
-        $listResult = $connection->fetchAll("LIST @~/$stageName2/;");
-        $this->assertNotEmpty($listResult, 'simple-date table files should be staged');
+            // Upload table 2 to stage
+            $connection->query("
+                COPY INTO @~/$stageName2/part
+                FROM (SELECT * FROM \"simple-date\")
+                FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER=',' COMPRESSION='GZIP')
+                OVERWRITE = TRUE;
+            ");
 
-        // Now test the download behavior using SnowsqlExportAdapter
-        $logger = new NullLogger();
-        $queryFactory = $this->createMock(SnowflakeQueryFactory::class);
-        $metadataProvider = $this->createMock(SnowflakeMetadataProvider::class);
+            // Verify both are in stage
+            $listResult = $connection->fetchAll("LIST @~/$stageName1/;");
+            $this->assertNotEmpty($listResult, 'simple table files should be staged');
 
-        $databaseConfig = SnowflakeDatabaseConfig::fromArray([
-            'host' => getenv('SNOWFLAKE_DB_HOST'),
-            'port' => getenv('SNOWFLAKE_DB_PORT'),
-            'user' => getenv('SNOWFLAKE_DB_USER'),
-            '#password' => getenv('SNOWFLAKE_DB_PASSWORD'),
-            'database' => getenv('SNOWFLAKE_DB_DATABASE'),
-            'schema' => $schema,
-            'warehouse' => getenv('SNOWFLAKE_DB_WAREHOUSE'),
-        ]);
+            $listResult = $connection->fetchAll("LIST @~/$stageName2/;");
+            $this->assertNotEmpty($listResult, 'simple-date table files should be staged');
 
-        // Create ODBC connection using the connection factory
-        $connectionFactory = new SnowflakeConnectionFactory($logger, 5);
-        $odbcConnection = $connectionFactory->create($databaseConfig);
+            // Now test the download behavior using SnowsqlExportAdapter
+            $logger = new NullLogger();
+            $queryFactory = $this->createMock(SnowflakeQueryFactory::class);
+            $metadataProvider = $this->createMock(SnowflakeMetadataProvider::class);
 
-        $adapter = new SnowsqlExportAdapter(
-            $logger,
-            $odbcConnection,
-            $queryFactory,
-            $metadataProvider,
-            $databaseConfig,
-        );
+            $databaseConfig = SnowflakeDatabaseConfig::fromArray([
+                'host' => (string) getenv('SNOWFLAKE_DB_HOST'),
+                'port' => (string) getenv('SNOWFLAKE_DB_PORT'),
+                'user' => (string) getenv('SNOWFLAKE_DB_USER'),
+                '#password' => (string) getenv('SNOWFLAKE_DB_PASSWORD'),
+                'database' => (string) getenv('SNOWFLAKE_DB_DATABASE'),
+                'schema' => $schema,
+                'warehouse' => (string) getenv('SNOWFLAKE_DB_WAREHOUSE'),
+            ]);
 
-        // Create export config for downloading "simple" table
-        $exportConfig = $this->createMock(ExportConfig::class);
-        $exportConfig->method('getOutputTable')->willReturn($stageName1);
+            // Create ODBC connection using the connection factory
+            $connectionFactory = new SnowflakeConnectionFactory($logger, 5);
+            $odbcConnection = $connectionFactory->create($databaseConfig);
 
-        // Use reflection to call generateDownloadSql and execute the download
-        $reflection = new ReflectionClass($adapter);
-        $method = $reflection->getMethod('generateDownloadSql');
-        $method->setAccessible(true);
+            $adapter = new SnowsqlExportAdapter(
+                $logger,
+                $odbcConnection,
+                $queryFactory,
+                $metadataProvider,
+                $databaseConfig,
+            );
 
-        $outputDir = $temp->getTmpFolder();
-        $downloadCommand = $method->invoke($adapter, $exportConfig, $outputDir);
+            // Create export config for downloading "simple" table
+            $exportConfig = $this->createMock(ExportConfig::class);
+            $exportConfig->method('getOutputTable')->willReturn($stageName1);
 
-        // Execute the download command
-        assert(is_string($downloadCommand));
-        $process = Process::fromShellCommandline($downloadCommand);
-        $process->setTimeout(null);
-        $process->run();
+            // Use reflection to call generateDownloadSql and execute the download
+            $reflection = new ReflectionClass($adapter);
+            $method = $reflection->getMethod('generateDownloadSql');
+            $method->setAccessible(true);
 
-        $this->assertTrue(
-            $process->isSuccessful(),
-            'Download process should succeed. Error: ' . $process->getErrorOutput(),
-        );
+            $outputDir = $temp->getTmpFolder();
+            $downloadCommand = $method->invoke($adapter, $exportConfig, $outputDir);
 
-        // Parse the snowsql output to count downloaded files
-        $output = $process->getOutput();
+            // Execute the download command
+            $this->assertIsString($downloadCommand, 'generateDownloadSql should return a string command');
+            $process = Process::fromShellCommandline($downloadCommand);
+            $process->setTimeout(null);
+            $process->run();
 
-        // SnowSQL output format shows a table with DOWNLOADED status entries
-        // Count the number of lines with "DOWNLOADED" status (excluding header)
-        $downloadedCount = substr_count($output, '| DOWNLOADED |');
+            $this->assertTrue(
+                $process->isSuccessful(),
+                'Download process should succeed. Error: ' . $process->getErrorOutput(),
+            );
 
-        $this->assertEquals(
-            1,
-            $downloadedCount,
-            "Expected 1 file to be downloaded (only from simple/), but got $downloadedCount. " .
-            'This indicates the GET command without trailing slash matched multiple prefixes. ' .
-            "Output: $output",
-        );
+            // Parse the snowsql output to count downloaded files
+            $output = $process->getOutput();
 
-        // Verify downloaded files exist
-        $downloadedFiles = glob("$outputDir/*");
-        $this->assertNotFalse($downloadedFiles, 'glob() should not return false');
-        $this->assertCount(
-            1,
-            $downloadedFiles,
-            'Expected exactly 1 file in output directory',
-        );
+            // SnowSQL output format shows a table with DOWNLOADED status entries
+            // Count the number of lines with "DOWNLOADED" status (excluding header)
+            $downloadedCount = substr_count($output, '| DOWNLOADED |');
 
-        // Cleanup stage
-        $connection->query("REMOVE @~/$stageName1/;");
-        $connection->query("REMOVE @~/$stageName2/;");
+            $this->assertEquals(
+                1,
+                $downloadedCount,
+                "Expected 1 file to be downloaded (only from simple/), but got $downloadedCount. " .
+                'This indicates the GET command without trailing slash matched multiple prefixes. ' .
+                "Output: $output",
+            );
 
-        // Cleanup tables
-        $connection->query('DROP TABLE IF EXISTS "simple";');
-        $connection->query('DROP TABLE IF EXISTS "simple-date";');
+            // Verify downloaded files exist
+            $downloadedFiles = glob("$outputDir/*");
+            $this->assertNotFalse($downloadedFiles, 'glob() should not return false');
+            $this->assertCount(
+                1,
+                $downloadedFiles,
+                'Expected exactly 1 file in output directory',
+            );
+        } finally {
+            // Always cleanup stage files and tables, even if test fails
+            try {
+                $connection->query("REMOVE @~/$stageName1/;");
+            } catch (Throwable $e) {
+                // Ignore cleanup errors
+            }
+            try {
+                $connection->query("REMOVE @~/$stageName2/;");
+            } catch (Throwable $e) {
+                // Ignore cleanup errors
+            }
+            try {
+                $connection->query('DROP TABLE IF EXISTS "simple";');
+            } catch (Throwable $e) {
+                // Ignore cleanup errors
+            }
+            try {
+                $connection->query('DROP TABLE IF EXISTS "simple-date";');
+            } catch (Throwable $e) {
+                // Ignore cleanup errors
+            }
+        }
     }
 }

--- a/tests/phpunit/SnowsqlExportAdapterTest.php
+++ b/tests/phpunit/SnowsqlExportAdapterTest.php
@@ -6,13 +6,20 @@ namespace Keboola\DbExtractor\Tests;
 
 use Keboola\DbExtractor\Adapter\ODBC\OdbcConnection;
 use Keboola\DbExtractor\Configuration\ValueObject\SnowflakeDatabaseConfig;
+use Keboola\DbExtractor\Extractor\SnowflakeConnectionFactory;
 use Keboola\DbExtractor\Extractor\SnowflakeMetadataProvider;
 use Keboola\DbExtractor\Extractor\SnowflakeQueryFactory;
 use Keboola\DbExtractor\Extractor\SnowsqlExportAdapter;
+use Keboola\DbExtractor\FunctionalTests\DatabaseManager;
+use Keboola\DbExtractor\FunctionalTests\TestConnection;
 use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
+use Keboola\Temp\Temp;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Psr\Log\Test\TestLogger;
 use ReflectionClass;
+use Symfony\Component\Process\Process;
+use Throwable;
 
 class SnowsqlExportAdapterTest extends TestCase
 {
@@ -141,5 +148,167 @@ class SnowsqlExportAdapterTest extends TestCase
             'table name with dots' => ['in.c-main.escaping'],
             'table name with special characters' => ['my-table_123'],
         ];
+    }
+
+    public function testGetCommandWithTrailingSlashPreventsDownloadingPrefixMatchedFiles(): void
+    {
+        $connection = TestConnection::createConnection();
+        $temp = new Temp();
+
+        $schema = (string) getenv('SNOWFLAKE_DB_SCHEMA');
+        $manager = new DatabaseManager($connection);
+
+        // Create and populate first table: "simple"
+        $manager->createTable(
+            'simple',
+            ['id' => 'NUMBER', 'name' => 'VARCHAR'],
+            $schema,
+        );
+        $manager->insertRows(
+            'simple',
+            ['id', 'name'],
+            [
+                [1, 'foo'],
+                [2, 'bar'],
+                [3, 'baz'],
+            ],
+        );
+
+        // Create and populate second table: "simple-date" (prefix matches "simple")
+        $manager->createTable(
+            'simple-date',
+            ['id' => 'NUMBER', 'name' => 'VARCHAR', 'created_at' => 'DATE'],
+            $schema,
+        );
+        $manager->insertRows(
+            'simple-date',
+            ['id', 'name', 'created_at'],
+            [
+                [1, 'alpha', '2024-01-01'],
+                [2, 'beta', '2024-01-02'],
+            ],
+        );
+
+        // Manually stage BOTH tables simultaneously (simulates parallel runs)
+        // This is the key difference from normal functional tests
+        $stageName1 = 'in.c-main.simple';
+        $stageName2 = 'in.c-main.simple-date';
+
+        // Clean up any existing stage files first
+        try {
+            $connection->query("REMOVE @~/$stageName1/;");
+        } catch (Throwable $e) {
+            // Ignore errors if stage doesn't exist
+        }
+        try {
+            $connection->query("REMOVE @~/$stageName2/;");
+        } catch (Throwable $e) {
+            // Ignore errors if stage doesn't exist
+        }
+
+        // Upload table 1 to stage
+        $connection->query("
+            COPY INTO @~/$stageName1/part
+            FROM (SELECT * FROM \"simple\")
+            FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER=',' COMPRESSION='GZIP')
+            OVERWRITE = TRUE;
+        ");
+
+        // Upload table 2 to stage
+        $connection->query("
+            COPY INTO @~/$stageName2/part
+            FROM (SELECT * FROM \"simple-date\")
+            FILE_FORMAT = (TYPE=CSV FIELD_DELIMITER=',' COMPRESSION='GZIP')
+            OVERWRITE = TRUE;
+        ");
+
+        // Verify both are in stage
+        $listResult = $connection->fetchAll("LIST @~/$stageName1/;");
+        $this->assertNotEmpty($listResult, 'simple table files should be staged');
+
+        $listResult = $connection->fetchAll("LIST @~/$stageName2/;");
+        $this->assertNotEmpty($listResult, 'simple-date table files should be staged');
+
+        // Now test the download behavior using SnowsqlExportAdapter
+        $logger = new NullLogger();
+        $queryFactory = $this->createMock(SnowflakeQueryFactory::class);
+        $metadataProvider = $this->createMock(SnowflakeMetadataProvider::class);
+
+        $databaseConfig = SnowflakeDatabaseConfig::fromArray([
+            'host' => getenv('SNOWFLAKE_DB_HOST'),
+            'port' => getenv('SNOWFLAKE_DB_PORT'),
+            'user' => getenv('SNOWFLAKE_DB_USER'),
+            '#password' => getenv('SNOWFLAKE_DB_PASSWORD'),
+            'database' => getenv('SNOWFLAKE_DB_DATABASE'),
+            'schema' => $schema,
+            'warehouse' => getenv('SNOWFLAKE_DB_WAREHOUSE'),
+        ]);
+
+        // Create ODBC connection using the connection factory
+        $connectionFactory = new SnowflakeConnectionFactory($logger, 5);
+        $odbcConnection = $connectionFactory->create($databaseConfig);
+
+        $adapter = new SnowsqlExportAdapter(
+            $logger,
+            $odbcConnection,
+            $queryFactory,
+            $metadataProvider,
+            $databaseConfig,
+        );
+
+        // Create export config for downloading "simple" table
+        $exportConfig = $this->createMock(ExportConfig::class);
+        $exportConfig->method('getOutputTable')->willReturn($stageName1);
+
+        // Use reflection to call generateDownloadSql and execute the download
+        $reflection = new ReflectionClass($adapter);
+        $method = $reflection->getMethod('generateDownloadSql');
+        $method->setAccessible(true);
+
+        $outputDir = $temp->getTmpFolder();
+        $downloadCommand = $method->invoke($adapter, $exportConfig, $outputDir);
+
+        // Execute the download command
+        assert(is_string($downloadCommand));
+        $process = Process::fromShellCommandline($downloadCommand);
+        $process->setTimeout(null);
+        $process->run();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            'Download process should succeed. Error: ' . $process->getErrorOutput(),
+        );
+
+        // Parse the snowsql output to count downloaded files
+        $output = $process->getOutput();
+
+        // SnowSQL output format shows a table with DOWNLOADED status entries
+        // Count the number of lines with "DOWNLOADED" status (excluding header)
+        $downloadedCount = substr_count($output, '| DOWNLOADED |');
+
+        $this->assertEquals(
+            1,
+            $downloadedCount,
+            "Expected 1 file to be downloaded (only from simple/), but got $downloadedCount. " .
+            'This indicates the GET command without trailing slash matched multiple prefixes. ' .
+            "Output: $output",
+        );
+
+        // Verify downloaded files exist
+        $downloadedFiles = glob("$outputDir/*");
+        $this->assertNotFalse($downloadedFiles, 'glob() should not return false');
+        $this->assertCount(
+            1,
+            $downloadedFiles,
+            'Expected exactly 1 file in output directory',
+        );
+
+        // Cleanup stage
+        $connection->query("REMOVE @~/$stageName1/;");
+        $connection->query("REMOVE @~/$stageName2/;");
+
+        // Cleanup tables
+        $connection->query('DROP TABLE IF EXISTS "simple";');
+        $connection->query('DROP TABLE IF EXISTS "simple-date";');
     }
 }

--- a/tests/phpunit/SnowsqlExportAdapterTest.php
+++ b/tests/phpunit/SnowsqlExportAdapterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Keboola\DbExtractor\Adapter\ODBC\OdbcConnection;
+use Keboola\DbExtractor\Configuration\ValueObject\SnowflakeDatabaseConfig;
+use Keboola\DbExtractor\Extractor\SnowflakeMetadataProvider;
+use Keboola\DbExtractor\Extractor\SnowflakeQueryFactory;
+use Keboola\DbExtractor\Extractor\SnowsqlExportAdapter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\Test\TestLogger;
+use ReflectionClass;
+
+class SnowsqlExportAdapterTest extends TestCase
+{
+    /**
+     * @dataProvider cleanupTableStageDataProvider
+     */
+    public function testCleanupTableStageUsesTrailingSlash(string $tableName, string $expectedSql): void
+    {
+        $logger = new TestLogger();
+
+        $connection = $this->createMock(OdbcConnection::class);
+        $connection
+            ->expects($this->once())
+            ->method('query')
+            ->with($expectedSql);
+
+        $queryFactory = $this->createMock(SnowflakeQueryFactory::class);
+        $metadataProvider = $this->createMock(SnowflakeMetadataProvider::class);
+
+        $databaseConfig = $this->createMock(SnowflakeDatabaseConfig::class);
+        $databaseConfig->method('getHost')->willReturn('test.snowflakecomputing.com');
+        $databaseConfig->method('getUsername')->willReturn('testuser');
+        $databaseConfig->method('getPassword')->willReturn('testpass');
+        $databaseConfig->method('getDatabase')->willReturn('testdb');
+        $databaseConfig->method('hasWarehouse')->willReturn(false);
+        $databaseConfig->method('hasSchema')->willReturn(false);
+        $databaseConfig->method('hasPrivateKey')->willReturn(false);
+
+        $adapter = new SnowsqlExportAdapter(
+            $logger,
+            $connection,
+            $queryFactory,
+            $metadataProvider,
+            $databaseConfig,
+        );
+
+        $reflection = new ReflectionClass($adapter);
+        $method = $reflection->getMethod('cleanupTableStage');
+        $method->setAccessible(true);
+        $method->invoke($adapter, $tableName);
+    }
+
+    public function cleanupTableStageDataProvider(): array
+    {
+        return [
+            'simple table name' => [
+                'my_table',
+                'REMOVE @~/my_table/;',
+            ],
+            'table name with prefix that could match other tables' => [
+                'r_executive_brand_revenue',
+                'REMOVE @~/r_executive_brand_revenue/;',
+            ],
+            'table name that is prefix of another' => [
+                'orders',
+                'REMOVE @~/orders/;',
+            ],
+            'table name with dots' => [
+                'in.c-main.escaping',
+                'REMOVE @~/in.c-main.escaping/;',
+            ],
+            'table name with special characters' => [
+                'my-table_123',
+                'REMOVE @~/my-table_123/;',
+            ],
+        ];
+    }
+}

--- a/tests/phpunit/SnowsqlExportAdapterTest.php
+++ b/tests/phpunit/SnowsqlExportAdapterTest.php
@@ -9,6 +9,7 @@ use Keboola\DbExtractor\Configuration\ValueObject\SnowflakeDatabaseConfig;
 use Keboola\DbExtractor\Extractor\SnowflakeMetadataProvider;
 use Keboola\DbExtractor\Extractor\SnowflakeQueryFactory;
 use Keboola\DbExtractor\Extractor\SnowsqlExportAdapter;
+use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
 use ReflectionClass;
@@ -77,6 +78,68 @@ class SnowsqlExportAdapterTest extends TestCase
                 'my-table_123',
                 'REMOVE @~/my-table_123/;',
             ],
+        ];
+    }
+
+    /**
+     * @dataProvider generateDownloadSqlDataProvider
+     */
+    public function testGenerateDownloadSqlUsesTrailingSlash(string $tableName): void
+    {
+        $logger = new TestLogger();
+
+        $connection = $this->createMock(OdbcConnection::class);
+        $connection->method('quoteIdentifier')->willReturnCallback(fn($val) => '"' . $val . '"');
+
+        $queryFactory = $this->createMock(SnowflakeQueryFactory::class);
+        $metadataProvider = $this->createMock(SnowflakeMetadataProvider::class);
+
+        $databaseConfig = $this->createMock(SnowflakeDatabaseConfig::class);
+        $databaseConfig->method('getHost')->willReturn('test.snowflakecomputing.com');
+        $databaseConfig->method('getUsername')->willReturn('testuser');
+        $databaseConfig->method('getPassword')->willReturn('testpass');
+        $databaseConfig->method('getDatabase')->willReturn('testdb');
+        $databaseConfig->method('hasWarehouse')->willReturn(false);
+        $databaseConfig->method('hasSchema')->willReturn(false);
+        $databaseConfig->method('hasPrivateKey')->willReturn(false);
+
+        $adapter = new SnowsqlExportAdapter(
+            $logger,
+            $connection,
+            $queryFactory,
+            $metadataProvider,
+            $databaseConfig,
+        );
+
+        $exportConfig = $this->createMock(ExportConfig::class);
+        $exportConfig->method('getOutputTable')->willReturn($tableName);
+
+        $reflection = new ReflectionClass($adapter);
+        $method = $reflection->getMethod('generateDownloadSql');
+        $method->setAccessible(true);
+        $method->invoke($adapter, $exportConfig, '/tmp/output');
+
+        // Check that the debug log contains GET command with trailing slash
+        $debugLogs = array_filter($logger->records, fn($record) => $record['level'] === 'debug');
+        $this->assertNotEmpty($debugLogs, 'Expected debug log to be recorded');
+
+        $logMessage = end($debugLogs)['message'];
+        $expectedGetCommand = sprintf('GET @~/%s/ file:///tmp/output;', $tableName);
+        $this->assertStringContainsString(
+            $expectedGetCommand,
+            $logMessage,
+            sprintf('Expected GET command with trailing slash for table "%s"', $tableName),
+        );
+    }
+
+    public function generateDownloadSqlDataProvider(): array
+    {
+        return [
+            'simple table name' => ['my_table'],
+            'table name with prefix that could match other tables' => ['r_executive_brand_revenue'],
+            'table name that is prefix of another' => ['orders'],
+            'table name with dots' => ['in.c-main.escaping'],
+            'table name with special characters' => ['my-table_123'],
         ];
     }
 }


### PR DESCRIPTION
## Summary

Fixes a race condition in parallel extractions where Snowflake stage commands use prefix matching behavior instead of exact directory matching. This causes cleanup and download operations to affect unintended files when table names share prefixes (e.g., `r_executive_brand_revenue` would match files for `r_executive_brand_revenue_orders`).

The fix adds trailing slashes to both REMOVE and GET commands, ensuring Snowflake uses exact directory matching instead of prefix matching.

**Linear ticket:** AJDA-2184

## Changes

1. **`src/Extractor/SnowsqlExportAdapter.php`**: 
   - Added trailing slash to REMOVE command in `cleanupTableStage()` method: `REMOVE @~/table_name/;`
   - Added trailing slash to GET command in `generateDownloadSql()` method: `GET @~/table_name/ file://...`
2. **`tests/functional/run-action-row-debug-logging/expected-stdout`**: Updated expected output to match the new command formats
3. **`tests/phpunit/SnowsqlExportAdapterTest.php`**: Added new unit test that verifies the REMOVE command includes trailing slash for various table name patterns

## Review & Testing Checklist for Human

- [ ] Verify Snowflake's documented behavior that trailing slash changes from prefix matching to exact directory matching for both REMOVE and GET commands
- [ ] Test parallel extractions with tables that have prefix-matching names (e.g., `orders` and `orders_items`) to confirm files are no longer accidentally deleted or downloaded incorrectly
- [ ] Verify single extraction cleanup still works correctly after the change
- [ ] Review the unit test approach using reflection to test private method - consider if this is acceptable or if the method should be made protected/public for testability

**Recommended test plan:** Run two concurrent extraction jobs using the same Snowflake credentials where one table name is a prefix of another (e.g., `test_table` and `test_table_extended`). Verify both extractions complete successfully without file deletion or download errors.

### Notes

Requested by: Erik Žigo (@ErikZigo)

Link to Devin run: https://app.devin.ai/sessions/7b5e8cdac3af45e49a69c18830caaec9

## Release Notes
**Justification, description**

Fixes a critical bug where parallel extraction jobs using the same Snowflake credentials could accidentally delete or download each other's staged files when table names share prefixes.

**Plans for Customer Communication**

N/A

**Impact Analysis**

High impact for customers running parallel extractions. The fix is minimal (two trailing slashes) but prevents data corruption and loss scenarios.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A