### PR TITLE
[AJDA-2893] Include datatype length for TIMESTAMP/TIME columns in table manifest

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,6 +36,11 @@ parameters:
 			path: src/Extractor/SnowflakeMetadataProvider.php
 
 		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 5
+			path: src/Extractor/SnowflakeUtils.php
+
+		-
 			message: "#^Cannot cast mixed to int\\.$#"
 			count: 1
 			path: src/Extractor/SnowsqlExportAdapter.php

--- a/src/Extractor/SnowflakeMetadataProvider.php
+++ b/src/Extractor/SnowflakeMetadataProvider.php
@@ -195,18 +195,10 @@ class SnowflakeMetadataProvider implements MetadataProvider
 
     private function processColumnData(ColumnBuilder $columnBuilder, array $column, array $primaryKeys): void
     {
-        $length = ($column['CHARACTER_MAXIMUM_LENGTH']) ? $column['CHARACTER_MAXIMUM_LENGTH'] : null;
-        if (is_null($length) && !is_null($column['NUMERIC_PRECISION'])) {
-            if (is_numeric($column['NUMERIC_SCALE'])) {
-                $length = $column['NUMERIC_PRECISION'] . ',' . $column['NUMERIC_SCALE'];
-            } else {
-                $length = $column['NUMERIC_PRECISION'];
-            }
-        }
         $columnBuilder
             ->setName($column['COLUMN_NAME'])
             ->setDefault($column['COLUMN_DEFAULT'])
-            ->setLength($length)
+            ->setLength(SnowflakeUtils::getColumnLength($column))
             ->setNullable(!(trim($column['IS_NULLABLE']) === 'NO'))
             ->setType($column['DATA_TYPE'])
             ->setOrdinalPosition((int) $column['ORDINAL_POSITION']);

--- a/src/Extractor/SnowflakeUtils.php
+++ b/src/Extractor/SnowflakeUtils.php
@@ -14,4 +14,36 @@ class SnowflakeUtils
         $length = $m[2] ?? null;
         return [$type, $length];
     }
+
+    /**
+     * @param array<string, mixed> $column
+     */
+    public static function getColumnLength(array $column): ?string
+    {
+        if (!empty($column['CHARACTER_MAXIMUM_LENGTH'])) {
+            return (string) $column['CHARACTER_MAXIMUM_LENGTH'];
+        }
+
+        if (!is_null($column['NUMERIC_PRECISION'])) {
+            if (is_numeric($column['NUMERIC_SCALE'])) {
+                return (string) $column['NUMERIC_PRECISION'] . ',' . (string) $column['NUMERIC_SCALE'];
+            }
+            return (string) $column['NUMERIC_PRECISION'];
+        }
+
+        if (!is_null($column['DATETIME_PRECISION'])
+            && self::isTemporalTypeWithPrecision((string) $column['DATA_TYPE'])
+        ) {
+            return (string) $column['DATETIME_PRECISION'];
+        }
+
+        return null;
+    }
+
+    private static function isTemporalTypeWithPrecision(string $dataType): bool
+    {
+        // Snowflake TIMESTAMP_NTZ/_LTZ/_TZ and TIME carry a fractional-seconds precision (0-9).
+        // DATE intentionally excluded: it has no precision and php-datatypes rejects a length for it.
+        return str_starts_with($dataType, 'TIMESTAMP') || $dataType === 'TIME';
+    }
 }

--- a/tests/functional/incremental-fetching-datetime-with-state/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-datetime-with-state/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-datetime/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-datetime/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-decimal-with-state/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-decimal-with-state/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-decimal/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-decimal/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-empty-rows/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-empty-rows/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-int-with-limit/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-int-with-limit/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-int-with-state-and-limit/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-int-with-state-and-limit/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-int-with-state/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-int-with-state/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-int-with-zero-limit/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-int-with-zero-limit/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/functional/incremental-fetching-int/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
+++ b/tests/functional/incremental-fetching-int/expected/data/out/tables/in.c-main.auto-increment-timestamp.csv.gz.manifest
@@ -251,6 +251,10 @@
                 "value": "TIMESTAMP_NTZ"
             },
             {
+                "key": "KBC.datatype.length",
+                "value": "9"
+            },
+            {
                 "key": "KBC.sourceName",
                 "value": "datetime"
             },

--- a/tests/phpunit/SnowflakeUtilsTest.php
+++ b/tests/phpunit/SnowflakeUtilsTest.php
@@ -50,4 +50,76 @@ class SnowflakeUtilsTest extends TestCase
             ['VARCHAR', '16777216'],
         ];
     }
+
+    /**
+     * @dataProvider getColumnLengthData
+     * @param array<string, mixed> $column
+     */
+    public function testGetColumnLength(array $column, ?string $expected): void
+    {
+        Assert::assertSame($expected, SnowflakeUtils::getColumnLength($column));
+    }
+
+    public function getColumnLengthData(): iterable
+    {
+        yield 'varchar uses character_maximum_length' => [
+            $this->columnRow(['CHARACTER_MAXIMUM_LENGTH' => '55', 'DATA_TYPE' => 'TEXT']),
+            '55',
+        ];
+        yield 'zero character_maximum_length has no length' => [
+            $this->columnRow(['CHARACTER_MAXIMUM_LENGTH' => '0', 'DATA_TYPE' => 'TEXT']),
+            null,
+        ];
+        yield 'number with scale' => [
+            $this->columnRow(['NUMERIC_PRECISION' => '38', 'NUMERIC_SCALE' => '0', 'DATA_TYPE' => 'NUMBER']),
+            '38,0',
+        ];
+        yield 'number without scale' => [
+            $this->columnRow(['NUMERIC_PRECISION' => '38', 'NUMERIC_SCALE' => null, 'DATA_TYPE' => 'NUMBER']),
+            '38',
+        ];
+        yield 'timestamp_ntz uses datetime_precision' => [
+            $this->columnRow(['DATETIME_PRECISION' => '9', 'DATA_TYPE' => 'TIMESTAMP_NTZ']),
+            '9',
+        ];
+        yield 'timestamp_tz uses datetime_precision' => [
+            $this->columnRow(['DATETIME_PRECISION' => '9', 'DATA_TYPE' => 'TIMESTAMP_TZ']),
+            '9',
+        ];
+        yield 'timestamp_ltz uses datetime_precision' => [
+            $this->columnRow(['DATETIME_PRECISION' => '3', 'DATA_TYPE' => 'TIMESTAMP_LTZ']),
+            '3',
+        ];
+        yield 'time uses datetime_precision' => [
+            $this->columnRow(['DATETIME_PRECISION' => '9', 'DATA_TYPE' => 'TIME']),
+            '9',
+        ];
+        yield 'timestamp with zero precision keeps zero' => [
+            $this->columnRow(['DATETIME_PRECISION' => '0', 'DATA_TYPE' => 'TIMESTAMP_NTZ']),
+            '0',
+        ];
+        yield 'date has no length even if datetime_precision is present' => [
+            $this->columnRow(['DATETIME_PRECISION' => '0', 'DATA_TYPE' => 'DATE']),
+            null,
+        ];
+        yield 'boolean has no length' => [
+            $this->columnRow(['DATA_TYPE' => 'BOOLEAN']),
+            null,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function columnRow(array $overrides): array
+    {
+        return array_merge([
+            'CHARACTER_MAXIMUM_LENGTH' => null,
+            'NUMERIC_PRECISION' => null,
+            'NUMERIC_SCALE' => null,
+            'DATETIME_PRECISION' => null,
+            'DATA_TYPE' => null,
+        ], $overrides);
+    }
 }


### PR DESCRIPTION
## Problem

When exporting a table, the generated manifest included `KBC.datatype.length` for text and numeric columns but **not** for TIMESTAMP/TIME columns, even though Snowflake types like `TIMESTAMP_NTZ(9)` carry a defined fractional-seconds precision. The custom-query export path (`getColumnsInfo()`) already produced the length, so manifests differed between the two export paths for the same column.

## Root cause

`SnowflakeMetadataProvider::processColumnData()` derived the column length only from `CHARACTER_MAXIMUM_LENGTH` (text) and `NUMERIC_PRECISION`/`NUMERIC_SCALE` (numeric). For TIMESTAMP/TIME columns both are `NULL`; Snowflake stores the precision in `DATETIME_PRECISION`, which the code never read.

## Fix

Derive `KBC.datatype.length` from `information_schema.columns.DATETIME_PRECISION` for `TIMESTAMP*`/`TIME` columns. `DATE` is deliberately excluded — it has no precision and `php-datatypes` rejects a length for it. This makes the table-export path consistent with the custom-query path.

## Changes

- Extract the length-derivation logic from `processColumnData()` into a pure, unit-testable helper `SnowflakeUtils::getColumnLength()`, adding the `DATETIME_PRECISION` fallback restricted via `isTemporalTypeWithPrecision()`.
- Add DB-free unit tests covering text, numeric, all `TIMESTAMP*` variants, `TIME`, `DATE` (excluded), zero precision, and zero character length.
- Update the 10 affected expected functional manifests (`in.c-main.auto-increment-timestamp.csv.gz.manifest`) — the `datetime` (TIMESTAMP_NTZ) column now carries `KBC.datatype.length: "9"`.

Behavior for text and numeric columns is unchanged.

Linear: AJDA-2893