### PR TITLE
chore: upgrade Snowflake ODBC driver 3.10.0 → 3.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@ FROM php:8.2-cli-trixie
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG SNOWFLAKE_ODBC_VERSION=3.10.0
+ARG SNOWFLAKE_ODBC_VERSION=3.18.0
 ARG SNOWFLAKE_SNOWSQL_VERSION=1.4.5
-ARG SNOWFLAKE_ODBC_GPG_KEY=5A125630709DD64B
+# Full 40-char fingerprint of the Snowflake signing key for 3.18.0 (key id
+# 3C98F63C9292CE02); trixie's debsig-verify resolves the policy dir by full fingerprint
+ARG SNOWFLAKE_ODBC_GPG_KEY=6C983AB7AFE2E5951C6C47B13C98F63C9292CE02
 ARG SNOWFLAKE_SNOWSQL_GPG_KEY=2A3149C82551A34A
 
 ENV LANGUAGE=en_US.UTF-8
@@ -29,6 +31,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         unixodbc \
         unixodbc-dev \
+        # runtime dependency of snowflake-odbc 3.18.0 (Depends: odbcinst)
+        odbcinst \
         libpq-dev \
         libicu-dev \
         gpg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         unzip \
         unixodbc \
         unixodbc-dev \
-        # runtime dependency of snowflake-odbc 3.18.0 (Depends: odbcinst)
         odbcinst \
         libpq-dev \
         libicu-dev \

--- a/docker/driver/snowflake-odbc-policy.pol
+++ b/docker/driver/snowflake-odbc-policy.pol
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <!DOCTYPE Policy SYSTEM "http://www.debian.org/debsig/1.0/policy.dtd">
 <Policy xmlns="https://www.debian.org/debsig/1.0/">
-    <Origin Name="Snowflake Computing" id="5A125630709DD64B" Description="Snowflake ODBC Driver DEB package"/>
+    <Origin Name="Snowflake Computing" id="6C983AB7AFE2E5951C6C47B13C98F63C9292CE02" Description="Snowflake ODBC Driver DEB package"/>
     <Selection>
-        <Required Type="origin" File="debsig.gpg" id="5A125630709DD64B"/>
+        <Required Type="origin" File="debsig.gpg" id="6C983AB7AFE2E5951C6C47B13C98F63C9292CE02"/>
     </Selection>
     <Verification MinOptional="0">
-        <Required Type="origin" File="debsig.gpg" id="5A125630709DD64B"/>
+        <Required Type="origin" File="debsig.gpg" id="6C983AB7AFE2E5951C6C47B13C98F63C9292CE02"/>
     </Verification>
 </Policy>


### PR DESCRIPTION
Linear: [DMD-1659](https://linear.app/keboola/issue/DMD-1659/snowflake-odbc-driver-audit-upgrade-3100-3180-across-keboola-org)

## What
- `SNOWFLAKE_ODBC_VERSION` 3.10.0 → 3.18.0
- `SNOWFLAKE_ODBC_GPG_KEY` → `6C983AB7AFE2E5951C6C47B13C98F63C9292CE02` — 3.18.0 is signed by a new key; trixie's debsig-verify (0.33) resolves the policy dir by the full 40-char issuer fingerprint. Same ids updated in `docker/driver/snowflake-odbc-policy.pol`.
- Added `odbcinst` apt package — snowflake-odbc 3.18.0 declares `Depends: odbcinst` (split out of unixodbc in trixie) and `dpkg -i` does not resolve dependencies.

SnowSQL (1.4.5, key `2A3149C82551A34A`) is untouched.

## Why
Snowflake recommends upgrading the ODBC driver to 3.18.0; org-wide rollout tracked in DMD-1659. Same recipe already validated and merged in keboola/connection#7765 and snowflake-transformation#39.

## Validation
Local `docker build` passes:
- `debsig: Verified package from 'Snowflake ODBC Driver DEB package' (Snowflake Computing)`
- `Setting up snowflake-odbc (3.18.0)`
- Signing key of the Azure-mirror deb verified from its `_gpgorigin` signature (issuer fpr `6C983AB7…9292CE02`)

Smoke test in the built image: `SnowflakeDSIIDriver` registered in `odbcinst -q -d`, PHP `odbc` extension loaded, `libSnowflake.so` present, `snowsql -v` → 1.4.5.

Functional tests against Snowflake run in CI (need repo secrets).