### PR TITLE
Retry snowsql stage download on transient failure

### DIFF
--- a/src/Extractor/SnowsqlExportAdapter.php
+++ b/src/Extractor/SnowsqlExportAdapter.php
@@ -174,6 +174,10 @@ class SnowsqlExportAdapter implements ExportAdapter
 
     protected function runDownloadCommandOnce(ExportConfig $exportConfig, string $csvFilePath): Process
     {
+        // Nothing is retryable until a failed attempt says otherwise, so an exception raised
+        // anywhere else in this method can never inherit a previous attempt's decision.
+        $this->downloadErrorIsRetryable = false;
+
         // Generate command
         $command = $this->generateDownloadSql($exportConfig, $csvFilePath);
         $this->logger->info('Downloading data from Snowflake.');

--- a/src/Extractor/SnowsqlExportAdapter.php
+++ b/src/Extractor/SnowsqlExportAdapter.php
@@ -16,11 +16,13 @@ use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
 use Keboola\DbExtractorConfig\Exception\InvalidArgumentException;
 use Keboola\Temp\Temp;
 use Psr\Log\LoggerInterface;
+use Retry\BackOff\BackOffPolicyInterface;
 use Retry\BackOff\ExponentialBackOffPolicy;
-use Retry\Policy\SimpleRetryPolicy;
+use Retry\Policy\CallableRetryPolicy;
 use Retry\RetryProxy;
 use SplFileInfo;
 use Symfony\Component\Process\Process;
+use Throwable;
 
 class SnowsqlExportAdapter implements ExportAdapter
 {
@@ -30,6 +32,20 @@ class SnowsqlExportAdapter implements ExportAdapter
      * GET download is repeated, which is idempotent (it re-downloads the same staged files).
      */
     protected const DOWNLOAD_MAX_ATTEMPTS = 5;
+
+    /**
+     * Snowsql reports every problem hit while reading the staged files from the blob storage with
+     * this prefix, e.g. "253002 (n/a): While getting file(s) there was an error: 'HTTPError('404
+     * Client Error: Not Found for url: ...')'". The files were listed successfully a moment before,
+     * so being unable to read them is transient and worth retrying.
+     */
+    private const DOWNLOAD_RETRYABLE_ERROR = 'While getting file(s) there was an error';
+
+    /** Snowsql reuses the error above for an empty stage, which is not a failure at all. */
+    private const DOWNLOAD_NO_RESULTS_ERROR = 'While getting file(s) there was an error: the file does not exist';
+
+    /** Set by the last failed download attempt; drives the retry decision. */
+    protected bool $downloadErrorIsRetryable = false;
 
     protected SnowflakeQueryFactory $queryFactory;
 
@@ -130,10 +146,30 @@ class SnowsqlExportAdapter implements ExportAdapter
     protected function createDownloadRetryProxy(): RetryProxy
     {
         return new RetryProxy(
-            new SimpleRetryPolicy(self::DOWNLOAD_MAX_ATTEMPTS),
-            new ExponentialBackOffPolicy(1000),
+            new CallableRetryPolicy(
+                fn (Throwable $e): bool => $this->downloadErrorIsRetryable,
+                self::DOWNLOAD_MAX_ATTEMPTS,
+            ),
+            $this->createDownloadBackOffPolicy(),
             $this->logger,
         );
+    }
+
+    protected function createDownloadBackOffPolicy(): BackOffPolicyInterface
+    {
+        return new ExponentialBackOffPolicy(1000);
+    }
+
+    /**
+     * Only a failure reported by snowsql while reading the staged files from the blob storage is
+     * retried - see DOWNLOAD_RETRYABLE_ERROR. Every other download failure (bad credentials, an
+     * unparseable GET result, a missing file, ...) keeps failing on the first attempt, exactly as
+     * before, so nothing that used to fail fast is now slowed down by the retries.
+     */
+    protected function isRetryableDownloadError(string $errorOutput): bool
+    {
+        return str_contains($errorOutput, self::DOWNLOAD_RETRYABLE_ERROR)
+            && !str_contains($errorOutput, self::DOWNLOAD_NO_RESULTS_ERROR);
     }
 
     protected function runDownloadCommandOnce(ExportConfig $exportConfig, string $csvFilePath): Process
@@ -153,12 +189,10 @@ class SnowsqlExportAdapter implements ExportAdapter
         if (!$process->isSuccessful()) {
             // SnowSQL throws an error when there are no results,
             // but the expected behavior is to return process with empty output
-            if (str_contains(
-                $process->getErrorOutput(),
-                'While getting file(s) there was an error: the file does not exist',
-            )) {
+            if (str_contains($process->getErrorOutput(), self::DOWNLOAD_NO_RESULTS_ERROR)) {
                 return $process;
             }
+            $this->downloadErrorIsRetryable = $this->isRetryableDownloadError($process->getErrorOutput());
             $this->logger->error(sprintf('Snowsql error, process output %s', $process->getOutput()));
             $this->logger->error(sprintf('Snowsql error: %s', $process->getErrorOutput()));
             throw new Exception(sprintf(

--- a/src/Extractor/SnowsqlExportAdapter.php
+++ b/src/Extractor/SnowsqlExportAdapter.php
@@ -31,7 +31,7 @@ class SnowsqlExportAdapter implements ExportAdapter
      * The COPY INTO to the internal stage runs before this and is not retried; only the
      * GET download is repeated, which is idempotent (it re-downloads the same staged files).
      */
-    protected const DOWNLOAD_MAX_ATTEMPTS = 5;
+    protected const DOWNLOAD_MAX_ATTEMPTS = 3;
 
     /**
      * Snowsql reports every problem hit while reading the staged files from the blob storage with

--- a/src/Extractor/SnowsqlExportAdapter.php
+++ b/src/Extractor/SnowsqlExportAdapter.php
@@ -16,11 +16,21 @@ use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
 use Keboola\DbExtractorConfig\Exception\InvalidArgumentException;
 use Keboola\Temp\Temp;
 use Psr\Log\LoggerInterface;
+use Retry\BackOff\ExponentialBackOffPolicy;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryProxy;
 use SplFileInfo;
 use Symfony\Component\Process\Process;
 
 class SnowsqlExportAdapter implements ExportAdapter
 {
+    /**
+     * Number of attempts for the snowsql download.
+     * The COPY INTO to the internal stage runs before this and is not retried; only the
+     * GET download is repeated, which is idempotent (it re-downloads the same staged files).
+     */
+    protected const DOWNLOAD_MAX_ATTEMPTS = 5;
+
     protected SnowflakeQueryFactory $queryFactory;
 
     protected SnowflakeMetadataProvider $metadataProvider;
@@ -101,6 +111,32 @@ class SnowsqlExportAdapter implements ExportAdapter
     }
 
     private function runDownloadCommand(ExportConfig $exportConfig, string $csvFilePath): Process
+    {
+        // The staged files already exist (COPY INTO succeeded before this call), so the
+        // GET download is idempotent and safe to retry. This only smooths over transient
+        // blips reaching the stage (e.g. a 404 / connection reset from the blob storage
+        // provider while fetching a freshly-staged file); a persistent failure still
+        // exhausts the attempts and re-throws the identical exception below, unchanged.
+        $process = $this->createDownloadRetryProxy()->call(
+            function () use ($exportConfig, $csvFilePath): Process {
+                return $this->runDownloadCommandOnce($exportConfig, $csvFilePath);
+            },
+        );
+        assert($process instanceof Process);
+
+        return $process;
+    }
+
+    protected function createDownloadRetryProxy(): RetryProxy
+    {
+        return new RetryProxy(
+            new SimpleRetryPolicy(self::DOWNLOAD_MAX_ATTEMPTS),
+            new ExponentialBackOffPolicy(1000),
+            $this->logger,
+        );
+    }
+
+    protected function runDownloadCommandOnce(ExportConfig $exportConfig, string $csvFilePath): Process
     {
         // Generate command
         $command = $this->generateDownloadSql($exportConfig, $csvFilePath);

--- a/tests/phpunit/SnowsqlExportAdapterTest.php
+++ b/tests/phpunit/SnowsqlExportAdapterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\Tests;
 
+use Exception;
 use Keboola\DbExtractor\Adapter\ODBC\OdbcConnection;
 use Keboola\DbExtractor\Configuration\ValueObject\SnowflakeDatabaseConfig;
 use Keboola\DbExtractor\Extractor\SnowflakeConnectionFactory;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Psr\Log\Test\TestLogger;
 use ReflectionClass;
+use ReflectionMethod;
 use Symfony\Component\Process\Process;
 use Throwable;
 
@@ -326,5 +328,72 @@ class SnowsqlExportAdapterTest extends TestCase
                 // Ignore cleanup errors
             }
         }
+    }
+
+    public function testRunDownloadCommandRetriesTransientFailureThenSucceeds(): void
+    {
+        $adapter = $this->createTestableAdapter();
+        // Two transient failures, then success on the third attempt.
+        $adapter->failuresBeforeSuccess = 2;
+
+        $exportConfig = $this->createMock(ExportConfig::class);
+        $exportConfig->method('getOutputTable')->willReturn('my_table');
+
+        $method = new ReflectionMethod(SnowsqlExportAdapter::class, 'runDownloadCommand');
+        $method->setAccessible(true);
+        $result = $method->invoke($adapter, $exportConfig, '/tmp/output');
+
+        $this->assertInstanceOf(Process::class, $result);
+        $this->assertSame(3, $adapter->attemptCount);
+    }
+
+    public function testRunDownloadCommandRethrowsSameExceptionAfterExhaustingAttempts(): void
+    {
+        $adapter = $this->createTestableAdapter();
+        // Never succeeds, so every attempt throws.
+        $adapter->failuresBeforeSuccess = PHP_INT_MAX;
+
+        $exportConfig = $this->createMock(ExportConfig::class);
+        $exportConfig->method('getOutputTable')->willReturn('my_table');
+
+        $method = new ReflectionMethod(SnowsqlExportAdapter::class, 'runDownloadCommand');
+        $method->setAccessible(true);
+
+        try {
+            $method->invoke($adapter, $exportConfig, '/tmp/output');
+            $this->fail('Expected exception was not thrown after exhausting download attempts');
+        } catch (Exception $e) {
+            // The original, unchanged error message is preserved after retries are exhausted.
+            $this->assertStringContainsString(
+                'File download error occurred processing [my_table]',
+                $e->getMessage(),
+            );
+        }
+
+        $this->assertSame($adapter->maxAttempts(), $adapter->attemptCount);
+    }
+
+    private function createTestableAdapter(): TestableSnowsqlExportAdapter
+    {
+        $connection = $this->createMock(OdbcConnection::class);
+        $queryFactory = $this->createMock(SnowflakeQueryFactory::class);
+        $metadataProvider = $this->createMock(SnowflakeMetadataProvider::class);
+
+        $databaseConfig = $this->createMock(SnowflakeDatabaseConfig::class);
+        $databaseConfig->method('getHost')->willReturn('test.snowflakecomputing.com');
+        $databaseConfig->method('getUsername')->willReturn('testuser');
+        $databaseConfig->method('getPassword')->willReturn('testpass');
+        $databaseConfig->method('getDatabase')->willReturn('testdb');
+        $databaseConfig->method('hasWarehouse')->willReturn(false);
+        $databaseConfig->method('hasSchema')->willReturn(false);
+        $databaseConfig->method('hasPrivateKey')->willReturn(false);
+
+        return new TestableSnowsqlExportAdapter(
+            new NullLogger(),
+            $connection,
+            $queryFactory,
+            $metadataProvider,
+            $databaseConfig,
+        );
     }
 }

--- a/tests/phpunit/SnowsqlExportAdapterTest.php
+++ b/tests/phpunit/SnowsqlExportAdapterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\DbExtractor\Tests;
 
-use Exception;
+use Keboola\CommonExceptions\UserExceptionInterface;
 use Keboola\DbExtractor\Adapter\ODBC\OdbcConnection;
 use Keboola\DbExtractor\Configuration\ValueObject\SnowflakeDatabaseConfig;
 use Keboola\DbExtractor\Extractor\SnowflakeConnectionFactory;
@@ -362,12 +362,14 @@ class SnowsqlExportAdapterTest extends TestCase
         try {
             $method->invoke($adapter, $exportConfig, '/tmp/output');
             $this->fail('Expected exception was not thrown after exhausting download attempts');
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             // The original, unchanged error message is preserved after retries are exhausted.
             $this->assertStringContainsString(
                 'File download error occurred processing [my_table]',
                 $e->getMessage(),
             );
+            // Still not a user error, so the job keeps ending with exactly the same exit code as before.
+            $this->assertNotInstanceOf(UserExceptionInterface::class, $e);
         }
 
         $this->assertSame($adapter->maxAttempts(), $adapter->attemptCount);

--- a/tests/phpunit/SnowsqlExportAdapterTest.php
+++ b/tests/phpunit/SnowsqlExportAdapterTest.php
@@ -375,6 +375,67 @@ class SnowsqlExportAdapterTest extends TestCase
         $this->assertSame($adapter->maxAttempts(), $adapter->attemptCount);
     }
 
+    /**
+     * Anything other than a blob storage read error must keep failing on the very first attempt,
+     * so no failure that used to be reported immediately is now delayed by the retries.
+     */
+    public function testRunDownloadCommandDoesNotRetryNonTransientFailure(): void
+    {
+        $adapter = $this->createTestableAdapter();
+        $adapter->failuresBeforeSuccess = PHP_INT_MAX;
+        $adapter->simulateRetryableError = false;
+
+        $exportConfig = $this->createMock(ExportConfig::class);
+        $exportConfig->method('getOutputTable')->willReturn('my_table');
+
+        $method = new ReflectionMethod(SnowsqlExportAdapter::class, 'runDownloadCommand');
+        $method->setAccessible(true);
+
+        try {
+            $method->invoke($adapter, $exportConfig, '/tmp/output');
+            $this->fail('Expected exception was not thrown');
+        } catch (Throwable $e) {
+            $this->assertStringContainsString(
+                'File download error occurred processing [my_table]',
+                $e->getMessage(),
+            );
+        }
+
+        $this->assertSame(1, $adapter->attemptCount);
+    }
+
+    /**
+     * @dataProvider retryableDownloadErrorProvider
+     */
+    public function testIsRetryableDownloadError(string $errorOutput, bool $expected): void
+    {
+        $method = new ReflectionMethod(SnowsqlExportAdapter::class, 'isRetryableDownloadError');
+        $method->setAccessible(true);
+
+        $this->assertSame($expected, $method->invoke($this->createTestableAdapter(), $errorOutput));
+    }
+
+    public function retryableDownloadErrorProvider(): array
+    {
+        return [
+            'blob storage read error that ended a job with an internal error' => [
+                "253002 (n/a): While getting file(s) there was an error: 'HTTPError('404 Client "
+                    . "Error: Not Found for url: <url>')', this might be caused by your access to "
+                    . 'the blob storage provider, or by Snowflake.',
+                true,
+            ],
+            'empty stage is not a failure and must not be retried' => [
+                '253002 (n/a): While getting file(s) there was an error: the file does not exist',
+                false,
+            ],
+            'bad credentials must keep failing immediately' => [
+                '250001 (08001): Failed to connect to DB: Incorrect username or password was specified.',
+                false,
+            ],
+            'empty error output' => ['', false],
+        ];
+    }
+
     private function createTestableAdapter(): TestableSnowsqlExportAdapter
     {
         $connection = $this->createMock(OdbcConnection::class);

--- a/tests/phpunit/TestableSnowsqlExportAdapter.php
+++ b/tests/phpunit/TestableSnowsqlExportAdapter.php
@@ -7,14 +7,14 @@ namespace Keboola\DbExtractor\Tests;
 use Exception;
 use Keboola\DbExtractor\Extractor\SnowsqlExportAdapter;
 use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
+use Retry\BackOff\BackOffPolicyInterface;
 use Retry\BackOff\NoBackOffPolicy;
-use Retry\Policy\SimpleRetryPolicy;
-use Retry\RetryProxy;
 use Symfony\Component\Process\Process;
 
 /**
- * Test double exercising the download retry logic in SnowsqlExportAdapter without
- * spawning a real snowsql process or sleeping between attempts.
+ * Test double exercising the download retry logic in SnowsqlExportAdapter without spawning a real
+ * snowsql process or sleeping between attempts. The retry policy itself is NOT overridden, so the
+ * tests run against the production attempt count and the production retryable-error predicate.
  */
 class TestableSnowsqlExportAdapter extends SnowsqlExportAdapter
 {
@@ -23,24 +23,25 @@ class TestableSnowsqlExportAdapter extends SnowsqlExportAdapter
     /** Number of leading attempts that throw before one succeeds. */
     public int $failuresBeforeSuccess = 0;
 
+    /** Whether the simulated failures look like a retryable blob storage read error. */
+    public bool $simulateRetryableError = true;
+
     public function maxAttempts(): int
     {
         return self::DOWNLOAD_MAX_ATTEMPTS;
     }
 
-    protected function createDownloadRetryProxy(): RetryProxy
+    protected function createDownloadBackOffPolicy(): BackOffPolicyInterface
     {
         // Same attempt count as production, but no back-off sleep so the test stays fast.
-        return new RetryProxy(
-            new SimpleRetryPolicy(self::DOWNLOAD_MAX_ATTEMPTS),
-            new NoBackOffPolicy(),
-        );
+        return new NoBackOffPolicy();
     }
 
     protected function runDownloadCommandOnce(ExportConfig $exportConfig, string $csvFilePath): Process
     {
         $this->attemptCount++;
         if ($this->attemptCount <= $this->failuresBeforeSuccess) {
+            $this->downloadErrorIsRetryable = $this->simulateRetryableError;
             throw new Exception(sprintf(
                 'File download error occurred processing [%s]',
                 $exportConfig->getOutputTable(),

--- a/tests/phpunit/TestableSnowsqlExportAdapter.php
+++ b/tests/phpunit/TestableSnowsqlExportAdapter.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbExtractor\Tests;
+
+use Exception;
+use Keboola\DbExtractor\Extractor\SnowsqlExportAdapter;
+use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
+use Retry\BackOff\NoBackOffPolicy;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryProxy;
+use Symfony\Component\Process\Process;
+
+/**
+ * Test double exercising the download retry logic in SnowsqlExportAdapter without
+ * spawning a real snowsql process or sleeping between attempts.
+ */
+class TestableSnowsqlExportAdapter extends SnowsqlExportAdapter
+{
+    public int $attemptCount = 0;
+
+    /** Number of leading attempts that throw before one succeeds. */
+    public int $failuresBeforeSuccess = 0;
+
+    public function maxAttempts(): int
+    {
+        return self::DOWNLOAD_MAX_ATTEMPTS;
+    }
+
+    protected function createDownloadRetryProxy(): RetryProxy
+    {
+        // Same attempt count as production, but no back-off sleep so the test stays fast.
+        return new RetryProxy(
+            new SimpleRetryPolicy(self::DOWNLOAD_MAX_ATTEMPTS),
+            new NoBackOffPolicy(),
+        );
+    }
+
+    protected function runDownloadCommandOnce(ExportConfig $exportConfig, string $csvFilePath): Process
+    {
+        $this->attemptCount++;
+        if ($this->attemptCount <= $this->failuresBeforeSuccess) {
+            throw new Exception(sprintf(
+                'File download error occurred processing [%s]',
+                $exportConfig->getOutputTable(),
+            ));
+        }
+
+        return Process::fromShellCommandline('true');
+    }
+}


### PR DESCRIPTION
## What

Wraps the `snowsql GET` download step in `SnowsqlExportAdapter` in a bounded retry (5 attempts, exponential back-off) using the already-present `keboola/retry` dependency.

## Why

`keboola.ex-db-snowflake` jobs occasionally end with an opaque internal error (exit 2) at `src/Extractor/SnowsqlExportAdapter.php` while downloading the exported CSV from the Snowflake internal stage:

```
Snowsql error: 253002 (n/a): While getting file(s) there was an error:
'HTTPError('404 Client Error: Not Found for url: ...s3.amazonaws.com/.../part_0_0_0.csv.gz')',
this might be caused by your access to the blob storage provider, or by Snowflake.
-> Exception: File download error occurred processing [<table>]  (SnowsqlExportAdapter.php:128)
```

The SQL statements (including the `COPY INTO` that stages the file) all execute successfully; only the final `GET` of the freshly-staged file fails with a transient blob-storage/stage error. Snowflake's own message flags it as an infra-side condition. Simply retrying the download recovers from it.

## Behaviour impact: none — defensive-only

- **Happy path unchanged.** On a successful download the retry proxy invokes the download once and returns immediately — identical result, identical output.
- **No-results path unchanged.** The existing "the file does not exist" branch returns the process without throwing, so it is never retried.
- **Persistent failures unchanged.** If the download keeps failing, the *identical* exception (`File download error occurred processing [...]`) is re-thrown after the attempts are exhausted — same message, same exit code. Nothing is swallowed.
- The `COPY INTO` runs *before* the retried block and is **not** re-executed; only the idempotent `GET` (re-downloads the same staged files) is repeated. Downstream `parseFiles()` still validates each file was downloaded and exists, so a partial download cannot masquerade as success.
- **Only the transient error is retried.** The retry predicate matches just the snowsql message that
  actually ends jobs with an internal error — `While getting file(s) there was an error` — and
  explicitly excludes the empty-stage variant of it. Every other download failure (bad credentials,
  an unparseable `GET` result, a missing file) still fails on the **first** attempt, so nothing that
  used to fail fast is now delayed by back-off.

The download body was extracted verbatim into `runDownloadCommandOnce()`; `runDownloadCommand()` now just wraps it in the retry proxy.

## Tests

- Added regression tests in `tests/phpunit/SnowsqlExportAdapterTest.php` (with a small `TestableSnowsqlExportAdapter` double — no real process, no sleep; it overrides only the back-off, so the tests run against the production attempt count and the production predicate):
  - retries a transient download failure and then succeeds (asserts the attempt count);
  - re-throws the same exception after exhausting all attempts, and asserts it is still **not** a user exception (so the exit code is unchanged);
  - a non-transient failure is **not** retried (exactly one attempt);
  - the retryable-error predicate itself, over the verbatim snowsql messages (blob storage read error, empty stage, bad credentials, empty output).
- Existing assertions are unmodified.
- Verified locally in the component's own Docker image (`docker compose run dev`):
  - `phpcs` clean, `phpstan --level=max` clean.
  - `phpunit --testsuite unit`: **52 tests**, the 7 new ones green. The 12 errors are pre-existing
    and environmental — every one is `PrivateKeyIsNotValid` from `TestConnection::createConnection()`
    because no live Snowflake credentials are available outside CI. Unmodified `master` reports the
    *same* 12 errors (45 tests), so no previously-passing test changed state.
  - Retry proven effective: pinning `DOWNLOAD_MAX_ATTEMPTS = 1` makes the new retry test fail with
    the production exception, and restoring it to 5 makes it pass again.
  - The datadir/functional suite needs a live Snowflake database and cannot run locally; CI covers it.

## Evidence

Datadog (EU) failure logs for `keboola.ex-db-snowflake`: https://app.datadoghq.eu/logs?query=%28status%3A%28critical%20OR%20emergency%29%20service%3Ajob-queue-runner%20%28%40component%3Akeboola.ex-db-snowflake%20OR%20%40extra.component%3Akeboola.ex-db-snowflake%29%29


